### PR TITLE
fix deadlock in lastSQLError

### DIFF
--- a/SQLiteDB.swift
+++ b/SQLiteDB.swift
@@ -252,9 +252,13 @@ class SQLiteDB {
 	// Return last SQL error
 	func lastSQLError()->String {
 		var err:CString? = nil
-		dispatch_sync(queue) {
-			err = sqlite3_errmsg(self.db)
-		}
+    if dispatch_get_current_queue() != queue {
+      dispatch_sync(queue) {
+        err = sqlite3_errmsg(self.db)
+      }
+    } else {
+      err = sqlite3_errmsg(self.db)
+    }
 		return (err ? NSString(CString:err!) : "")
 	}
 	


### PR DESCRIPTION
If `db.lastSqlError()` is called by the library itself (such as lines [#157](https://github.com/rschmukler/SQLiteDB/blob/master/SQLiteDB.swift#L157), [#166](https://github.com/rschmukler/SQLiteDB/blob/master/SQLiteDB.swift#L166), [#196](https://github.com/rschmukler/SQLiteDB/blob/master/SQLiteDB.swift#L196)) you can get a deadlock.

This fixes that by checking that if we are already on that queue, we just run.
